### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/profiler.yml
+++ b/.github/workflows/profiler.yml
@@ -31,7 +31,7 @@ jobs:
         export PROFILER_COMPUTE_NAME=profilingTest
         echo PROFILER_COMPUTE_NAME=$PROFILER_COMPUTE_NAME >> $GITHUB_ENV
         echo PROFILER_COMPUTE_SIZE=Standard_F4s_v2 >> $GITHUB_ENV
-        echo "::set-output name=PROFILER_COMPUTE_NAME::$PROFILER_COMPUTE_NAME"
+        echo "PROFILER_COMPUTE_NAME=$PROFILER_COMPUTE_NAME" >> $GITHUB_OUTPUT
     - name: Check out repo
       uses: actions/checkout@v2
     - name: Create profiling compute


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter`